### PR TITLE
fix: handle CORS-restricted webhook endpoints gracefully

### DIFF
--- a/src/github-dispatch.ts
+++ b/src/github-dispatch.ts
@@ -26,27 +26,22 @@ export function buildWebhookRequestOptions({
   method,
   url,
 }: BuildWebhookRequestOptionsArgs): RequestInit {
+  const isGithub = isGithubWebhookUrl(url)
   const headers: Record<string, string> = {}
 
-  if (authToken) {
-    headers.Authorization = `Bearer ${authToken}`
-  }
-
-  if (isGithubWebhookUrl(url)) {
+  if (authToken) headers.Authorization = `Bearer ${authToken}`
+  if (isGithub) {
     headers.Accept = 'application/vnd.github+json'
     headers['X-GitHub-Api-Version'] = '2022-11-28'
-
-    return {
-      method,
-      headers,
-      body: JSON.stringify({
-        event_type: githubEventType || DEFAULT_GITHUB_EVENT_TYPE,
-      }),
-    }
   }
 
   return {
     method,
-    ...(Object.keys(headers).length > 0 && {headers}),
+    headers,
+    // Endpoints rarely include CORS headers; lets 'no-cors' reach the server without the browser throwing on the response
+    ...(isGithub ? {} : {mode: 'no-cors'}),
+    ...(isGithub && {
+      body: JSON.stringify({event_type: githubEventType || DEFAULT_GITHUB_EVENT_TYPE}),
+    }),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import WebhooksTrigger from './webhooks-trigger'
  * ```
  */
 export const webhooksTrigger = definePlugin<WebhooksTriggerOptions | void>((config) => {
-  const {name, title, encryptionSalt, text, githubEventType} = config || {}
+  const {name, title, icon, encryptionSalt, text, githubEventType} = config || {}
 
   return {
     name: 'sanity-plugin-webhooks-trigger',
@@ -29,12 +29,9 @@ export const webhooksTrigger = definePlugin<WebhooksTriggerOptions | void>((conf
       {
         name: name || 'webhooks-trigger',
         title: title || 'Deploy',
+        icon,
         component: WebhooksTrigger,
-        options: {
-          encryptionSalt,
-          text,
-          githubEventType,
-        },
+        options: {encryptionSalt, text, githubEventType},
         router: route.create('/*'),
       },
     ],

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -32,14 +32,13 @@ const WebhookFormModal = ({
 
       setIsSubmitting(true)
 
-      const updatedWebhook = {...webhook, name, url, method}
-      if (authToken) {
-        updatedWebhook.authToken = authToken
-      }
-      if (githubEventType) {
-        updatedWebhook.githubEventType = githubEventType
-      } else {
-        delete updatedWebhook.githubEventType
+      const updatedWebhook: Partial<Webhook> = {
+        ...webhook,
+        name,
+        url,
+        method,
+        ...(authToken && {authToken}),
+        ...(githubEventType && {githubEventType}),
       }
 
       await onSubmit(updatedWebhook)

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,24 +1,21 @@
 import CryptoJS from 'crypto-js'
 
+/** Derives an AES key from a salt using PBKDF2 */
+const deriveKey = (salt: string) =>
+  CryptoJS.PBKDF2(salt, salt, {keySize: 256 / 32, iterations: 1000}).toString()
+
 /**
  * Encrypts a token using AES encryption
- * @param token The token to encrypt
- * @param salt The salt used for key derivation
- * @returns The encrypted token as a string
+ * @param token - The token to encrypt
+ * @param salt - The salt used for key derivation
  */
-export const encryptToken = (token: string, salt: string): string => {
-  const key = CryptoJS.PBKDF2(salt, salt, {keySize: 256 / 32, iterations: 1000})
-  return CryptoJS.AES.encrypt(token, key.toString()).toString()
-}
+export const encryptToken = (token: string, salt: string): string =>
+  CryptoJS.AES.encrypt(token, deriveKey(salt)).toString()
 
 /**
  * Decrypts an encrypted token
- * @param encryptedToken The encrypted token to decrypt
- * @param salt The salt used for key derivation
- * @returns The decrypted token as a string
+ * @param encryptedToken - The encrypted token to decrypt
+ * @param salt - The salt used for key derivation
  */
-export const decryptToken = (encryptedToken: string, salt: string): string => {
-  const key = CryptoJS.PBKDF2(salt, salt, {keySize: 256 / 32, iterations: 1000})
-  const decrypted = CryptoJS.AES.decrypt(encryptedToken, key.toString())
-  return decrypted.toString(CryptoJS.enc.Utf8)
-}
+export const decryptToken = (encryptedToken: string, salt: string): string =>
+  CryptoJS.AES.decrypt(encryptedToken, deriveKey(salt)).toString(CryptoJS.enc.Utf8)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,8 @@
-import React from 'react'
+import type {ReactNode} from 'react'
 
 export interface WebhooksTriggerOptions {
   name?: string
-  icon?: React.ReactNode
+  icon?: ReactNode
   title?: string
   text?: string
   encryptionSalt?: string
@@ -24,7 +24,7 @@ export interface Webhook {
   authToken?: string
   githubEventType?: string
   lastRunTime?: string
-  lastRunStatus?: 'success' | 'failed'
+  lastRunStatus?: 'success' | 'failed' | 'triggered'
 }
 
 export interface WebhookFormModalProps {

--- a/src/webhooks-trigger.tsx
+++ b/src/webhooks-trigger.tsx
@@ -1,5 +1,4 @@
-import {AddIcon, ClockIcon, EditIcon, TrashIcon} from '@sanity/icons'
-import {TokenIcon} from '@sanity/icons'
+import {AddIcon, ClockIcon, EditIcon, TokenIcon, TrashIcon} from '@sanity/icons'
 import {
   Box,
   Button,
@@ -14,7 +13,7 @@ import {
 } from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
 import {customAlphabet} from 'nanoid'
-import {ReactElement, useCallback, useEffect, useState} from 'react'
+import {useCallback, useEffect, useState, type ReactElement} from 'react'
 import {useClient} from 'sanity'
 
 import {
@@ -28,13 +27,23 @@ import {Webhook, WebhooksTriggerConfig} from './types'
 
 const theme = buildTheme()
 const WEBHOOK_TYPE = 'webhook_triggers'
+const generateId = customAlphabet(
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+  12,
+)
 const defaultText =
   'Trigger webhooks right from Sanity, whether you need to rebuild a static website after content edits or run any other automated process.'
 
+const RUN_STATUS_CONFIG = {
+  success: {color: 'green', label: 'successful'},
+  triggered: {color: 'orange', label: 'triggered'},
+  failed: {color: 'red', label: 'failed'},
+} as const
+
 const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
   const {options} = tool
-  const encryptionSalt = options.encryptionSalt
-  const defaultGithubEventType = options.githubEventType || DEFAULT_GITHUB_EVENT_TYPE
+  const {encryptionSalt, text, githubEventType, triggerAll} = options
+  const defaultGithubEventType = githubEventType || DEFAULT_GITHUB_EVENT_TYPE
 
   const client = useClient({apiVersion: '2021-06-07'})
 
@@ -79,7 +88,7 @@ const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
         // Create new webhook
         await client.create({
           _type: WEBHOOK_TYPE,
-          _id: `${WEBHOOK_TYPE}.${customAlphabet('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', 12)()}`,
+          _id: `${WEBHOOK_TYPE}.${generateId()}`,
           ...webhook,
         })
       }
@@ -100,52 +109,47 @@ const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
   }, [])
 
   /**
-   * Handle the Webhook triggering
+   * Trigger a single webhook and record its status
    */
   const handleTriggerWebhook = useCallback(
     async (webhook: Webhook) => {
-      if (webhook.url) {
-        setTriggeringWebhook(webhook._id)
+      if (!webhook.url) return
+      setTriggeringWebhook(webhook._id)
 
-        try {
-          const authToken =
-            webhook.authToken && encryptionSalt
-              ? decryptToken(webhook.authToken, encryptionSalt)
-              : undefined
+      let lastRunStatus: Webhook['lastRunStatus'] = 'failed'
 
-          const response = await fetch(
-            webhook.url,
-            buildWebhookRequestOptions({
-              authToken,
-              githubEventType: webhook.githubEventType || defaultGithubEventType,
-              method: webhook.method,
-              url: webhook.url,
-            }),
-          )
+      try {
+        const authToken =
+          webhook.authToken && encryptionSalt
+            ? decryptToken(webhook.authToken, encryptionSalt)
+            : undefined
 
-          await client
-            .patch(webhook._id)
-            .set({
-              lastRunTime: new Date().toISOString(),
-              lastRunStatus: response.ok ? 'success' : 'failed',
-            })
-            .commit()
-        } catch (error) {
-          console.error('Failed to trigger webhook:', error)
+        // Non-GitHub endpoints rarely support CORS. buildWebhookRequestOptions
+        // handles it with mode: 'no-cors', making the response opaque — so we
+        // mark those as 'triggered' (sent successfully, outcome unknown).
+        const isGithub = isGithubWebhookUrl(webhook.url)
+        const response = await fetch(
+          webhook.url,
+          buildWebhookRequestOptions({
+            authToken,
+            githubEventType: webhook.githubEventType || defaultGithubEventType,
+            method: webhook.method,
+            url: webhook.url,
+          }),
+        )
 
-          await client
-            .patch(webhook._id)
-            .set({
-              lastRunTime: new Date().toISOString(),
-              lastRunStatus: 'failed',
-            })
-            .commit()
-        }
-
-        // Refresh the list to show updated status
-        fetchWebhooks()
-        setTriggeringWebhook(null)
+        lastRunStatus = isGithub ? (response.ok ? 'success' : 'failed') : 'triggered'
+      } catch (error) {
+        console.error('Failed to trigger webhook:', error)
       }
+
+      await client
+        .patch(webhook._id)
+        .set({lastRunTime: new Date().toISOString(), lastRunStatus})
+        .commit()
+
+      fetchWebhooks()
+      setTriggeringWebhook(null)
     },
     [client, defaultGithubEventType, fetchWebhooks, encryptionSalt],
   )
@@ -213,7 +217,7 @@ const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
                 Deploy via Webhooks
               </Heading>
               <Text size={2} style={{maxWidth: '70ch'}}>
-                {options.text || defaultText}
+                {text || defaultText}
               </Text>
             </Stack>
 
@@ -266,12 +270,12 @@ const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
                           <Flex gap={1} align="center">
                             <ClockIcon
                               fontSize={'1em'}
-                              color={webhook.lastRunStatus === 'success' ? 'green' : 'red'}
+                              color={RUN_STATUS_CONFIG[webhook.lastRunStatus].color}
                               style={{flexShrink: 0}}
                             />
                             <Text size={1} muted>
-                              Last {webhook.lastRunStatus === 'success' ? 'successful' : 'failed'}{' '}
-                              run: {new Date(webhook.lastRunTime).toLocaleString()}
+                              Last {RUN_STATUS_CONFIG[webhook.lastRunStatus].label} run:{' '}
+                              {new Date(webhook.lastRunTime).toLocaleString()}
                             </Text>
                           </Flex>
                         )}
@@ -287,13 +291,9 @@ const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
                             tone="positive"
                             onClick={() => handleTriggerWebhook(webhook)}
                             disabled={triggeringWebhook === webhook._id}
-                          >
-                            {triggeringWebhook === webhook._id ? (
-                              <Spinner size={1} />
-                            ) : (
-                              <Text size={1}>Trigger</Text>
-                            )}
-                          </Button>
+                            text={triggeringWebhook === webhook._id ? undefined : 'Trigger'}
+                            icon={triggeringWebhook === webhook._id ? Spinner : undefined}
+                          />
                           <Button
                             icon={EditIcon}
                             tone="default"
@@ -312,15 +312,15 @@ const WebhooksTrigger = ({tool}: WebhooksTriggerConfig): ReactElement => {
                 ))}
               </Stack>
 
-              {options.triggerAll !== false && webhooks.length > 1 && (
+              {triggerAll !== false && webhooks.length > 1 && (
                 <Flex marginTop={4} justify="flex-end">
                   <Button
                     tone="positive"
                     onClick={handleTriggerAllWebhooks}
                     disabled={triggeringAll || triggeringWebhook !== null}
-                  >
-                    {triggeringAll ? <Spinner size={1} /> : <Text size={1}>Trigger All</Text>}
-                  </Button>
+                    text={triggeringAll ? undefined : 'Trigger All'}
+                    icon={triggeringAll ? Spinner : undefined}
+                  />
                 </Flex>
               )}
             </>


### PR DESCRIPTION
## Summary

- Fixes #21 — non-GitHub webhooks (Cloudflare Pages, webhook.site, etc.) that lack CORS headers were incorrectly marked as "failed" even though the request reached the server successfully
- Adds `mode: 'no-cors'` for non-GitHub endpoints so `fetch()` doesn't throw on CORS-restricted responses
- Introduces a new **"triggered"** status (orange indicator) distinct from "success" (green) and "failed" (red) — used when the request was sent but the outcome is unverifiable
- GitHub dispatches still use `response.ok` as before (GitHub's API supports CORS properly)

## Refactoring

- Extracted `deriveKey()` helper in security.ts to remove PBKDF2 duplication
- Simplified modal form (conditional spread instead of mutation + `delete`)
- Pass `icon` option through to the Sanity tool config (was silently dropped)
- Use `import type` for ReactNode in types
- Cleaned up button props consistency and imports
